### PR TITLE
Add new refactor command for emr-c

### DIFF
--- a/emr-c.el
+++ b/emr-c.el
@@ -59,6 +59,11 @@
       (group-n 1
                (or "\"" "<") (* (not space)) (or "\"" ">"))))
 
+(defcustom emr-c-implementation-extensions
+  '("c" "cpp")
+  "Specify extensions that indicate current file is an implementation files."
+  :group 'emr)
+
 (defun emr-c:looking-at-include? ()
   (thing-at-point-looking-at emr-c:rx-include))
 
@@ -118,6 +123,56 @@ project, return all header files in the current directory."
     (--filter (-contains? '("h" "hpp") (file-name-extension it)))
     (-map 'file-relative-name)))
 
+
+(defvar emr-c:--semantic-tag-list '()
+  "[INTERNAL] List of semantic tags in current buffer.")
+
+(defun emr-c:--semantic-fetch-candidates ()
+  (setq emr-c:--semantic-tag-list nil)
+  (emr-c:--semantic-fetch-candidates-helper (semantic-fetch-tags) 0 nil))
+
+(defun emr-c:--semantic-fetch-candidates-helper (tags depth &optional class)
+  "Return a list of pairs '(DISPLAY . REAL), where DISPLAY is the string to be
+presented to user, while REAL is a semantic tag.
+
+TAGS are collection of Semantic tags in current buffer.
+DEPTH is current recursion depth.
+CLASS is the parent class."
+  (let ((spaces (make-string (* depth 2) ?\s))
+        (class class) cur-type display)
+    (cl-dolist (tag tags)
+      (when (listp tag)
+        (cl-case (setq cur-type (semantic-tag-class tag))
+          ((function variable type)
+           (let ((type-p (eq cur-type 'type)))
+             (unless (and (> depth 0) (not type-p))
+               (setq class nil))
+             (setq display (concat (if (null class)
+                                       spaces
+                                     (format "%s(%s) " spaces
+                                             (propertize (semantic-format-tag-name (semantic-tag-calculate-parent tag) nil t)
+                                                         'semantic-tag
+                                                         (semantic-tag-calculate-parent tag))))
+                                   (propertize (semantic-format-tag-summarize tag nil t)
+                                               'semantic-tag tag)))
+             (message "display is %s" display)
+             (and type-p
+                  (setq class (car tag)))
+             (push (cons display tag)
+                   emr-c:--semantic-tag-list)
+             ;; Recurse to children
+             (emr-c:--semantic-fetch-candidates-helper (semantic-tag-components tag)
+                                                       (1+ depth)
+                                                       class)))
+          ;; Don't do anything with packages or includes for now
+          ((package include)
+           (push (cons (propertize (semantic-format-tag-summarize tag nil t)
+                                   'semantic-tag tag)
+                       tag)
+                 emr-c:--semantic-tag-list))
+          ;; Catch-all
+          (t))))))
+
 ;;;###autoload
 (defun emr-c-insert-include (header)
   "Insert an include for HEADER and tidy the includes in the buffer."
@@ -139,7 +194,71 @@ project, return all header files in the current directory."
           (newline)
           (emr-c-tidy-includes))))))
 
-; ------------------
+;;;###autoload
+(defun emr-c:semantic-insert-function-prototype-or-implementation ()
+  "Insert function at point as prototype or implementation to
+other file (files with same names but different extensions),
+depends on file extension. If the file extension is in
+emr-c-implementation-extensions, insert \";\"; otherwise, insert
+{}. If there is more than one file, prompt for a file. If there's
+no file, prompt for the entire projectile project files."
+  (interactive)
+  (let (file other-files l)
+    (if (featurep 'projectile)
+        (progn
+          (setf other-files
+                (projectile-get-other-files (buffer-file-name)
+                                            (projectile-current-project-files)
+                                            nil))
+          (setf l (length other-files))
+          (setf file (concat (projectile-project-root)
+                             (cond ((> l 1)
+                                    (completing-read "Select a file to insert: "
+                                                     other-files))
+                                   ((= l 1)
+                                    (car other-files))
+                                   (t (projectile-find-file)))))))
+    (senator-copy-tag)
+    (with-current-buffer (if (featurep 'projectile)
+                             (find-file file)
+                           (ff-find-other-file))
+      (emr-c:--semantic-fetch-candidates)
+
+      (if emr-c:--semantic-tag-list
+          (progn
+            (setq emr-c:--semantic-tag-list (nreverse emr-c:--semantic-tag-list))
+            (emr-c:--semantic-insert-prototype (cdr (assoc (completing-read "Select a place to insert: "
+                                                                            emr-c:--semantic-tag-list)
+                                                           emr-c:--semantic-tag-list))))
+        (emr-c:--semantic-insert-prototype nil)))))
+
+(defun emr-c:--semantic-insert-prototype (tag)
+  "[INTERNAL] Insert a Semantic TAG to current buffer.
+If the file extension is in emr-c-implementation-extensions,
+insert \";\"; otherwise, insert {}."
+  (when tag
+    (semantic-go-to-tag tag)
+    (goto-char (semantic-tag-end tag))
+    (newline 2))
+
+  (senator-yank-tag)
+  (indent-according-to-mode)
+
+  (if (member (file-name-extension (buffer-file-name))
+              emr-c-implementation-extensions)
+      (progn
+        (insert "{}")
+        (forward-char -1)
+        (open-line 1)
+        (newline 1)
+        (indent-according-to-mode))
+    (insert ";")
+    (save-excursion
+      (forward-line 1)
+      (unless (c-guess-empty-line-p)
+        (newline 1)))))
+
+;; ------------------
 
 ;;; EMR Declarations
 


### PR DESCRIPTION
New command: emr-c:semantic-insert-function-prototype-or-implementation.

What it does: Insert function implementation/prototype into other file (file with the same name but different extension) from anywhere in your project. It was originated from this [StackExchange question](http://emacs.stackexchange.com/questions/7694/how-can-i-automatically-insert-a-prototype-in-foo-h-from-foo-c).

- If there's only one other file, the command inserts immediately into that file. Here is a demo (begins when `START DEMO` at the bottom):

![emr-c-semantic-insert-prototype-or-implementation](https://cloud.githubusercontent.com/assets/4818719/5896154/a314bbee-a562-11e4-9ee8-3447badb60fe.gif)

 In the beginning, **test.h** is empty. I ran the command in **test.c**, and it switches to **test.h** and insert immediately, since the file was empty. After the first function interface is inserted, when running the command on the second interface in **test.c** switched to **test.h** and prompt for a place to insert. I selected the first function inserted previously, and as a result, the second signature is inserted after it.

- If more than one, you are prompted to select a file. Demo:

![ijicd](https://cloud.githubusercontent.com/assets/4818719/5896194/5cff30ca-a563-11e4-9e5e-ed6d3d538d8d.gif)

- If there's none, you are prompted for the entire files in your project. After you select a file, a prompt offers a list of Semantic tags in the buffer.

- Insert prototype from **.cpp** to **.h**:

![emr-c-semantic-insert-prototype-or-implementation-cpp](https://cloud.githubusercontent.com/assets/4818719/5896208/8aa50d24-a563-11e4-8dc1-f5cdf8e736d8.gif)

As you see, you can insert based on a position of a tag. Note that when point was in **.cpp** file, it is inside the function body; you do not have to move point to function name to do this. When the file **.h** was switched, the command offered a list of Semantic tags for selecting one, and insert after it. If a tag is a child of another tag, it will be appended with prefix `(<parent tag name>)`.

- Similarly, insert implementation body from **.h** to **.cpp**. Notice that the pair `{}` is opened and indented nicely, create a body to write code immeidately:

![emr-c-semantic-insert-prototype-or-implementation-cpp-h-to-cpp](https://cloud.githubusercontent.com/assets/4818719/5896286/f3e7b6c8-a564-11e4-86bf-0a1b59cfae7a.gif)

**TODO**:

- Create an `emr-menu` for the command and future refactor commands.
- Make it behave smarter: if the tag at point is a function parameter, do not offer for inserting function prototype/implementation.
- Query all Semantic tags in current header file, filter and insert empty function definitions in corresponding source file.